### PR TITLE
Fix for Met significance when using reduced gsf tracks

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -71,8 +71,10 @@ PATElectronProducer::PATElectronProducer(const edm::ParameterSet & iConfig) :
   embedRecHits_(iConfig.getParameter<bool>( "embedRecHits" )),
   // pflow configurables
   useParticleFlow_(iConfig.getParameter<bool>( "useParticleFlow" )),
-  pfElecToken_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>( "pfElectronSource" ))),
-  pfCandidateMapToken_(mayConsume<edm::ValueMap<reco::PFCandidatePtr> >(iConfig.getParameter<edm::InputTag>( "pfCandidateMap" ))),
+  usePfCandidateMultiMap_(iConfig.getParameter<bool>( "usePfCandidateMultiMap" )),
+  pfElecToken_(!usePfCandidateMultiMap_ ? consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>( "pfElectronSource" )) : edm::EDGetTokenT<reco::PFCandidateCollection>()),
+  pfCandidateMapToken_(!usePfCandidateMultiMap_ ? mayConsume<edm::ValueMap<reco::PFCandidatePtr> >(iConfig.getParameter<edm::InputTag>( "pfCandidateMap" )) : edm::EDGetTokenT<edm::ValueMap<reco::PFCandidatePtr>>()),
+  pfCandidateMultiMapToken_(usePfCandidateMultiMap_ ? consumes<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(iConfig.getParameter<edm::InputTag>( "pfCandidateMultiMap" )) : edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>>()),
   embedPFCandidate_(iConfig.getParameter<bool>( "embedPFCandidate" )),
   // mva input variables
   reducedBarrelRecHitCollection_(iConfig.getParameter<edm::InputTag>("reducedBarrelRecHitCollection")),
@@ -196,6 +198,9 @@ PATElectronProducer::PATElectronProducer(const edm::ParameterSet & iConfig) :
     userDataHelper_ = PATUserDataHelper<Electron>(iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector());
   }
   
+  // consistency check
+  if (useParticleFlow_ && usePfCandidateMultiMap_) throw cms::Exception("Configuration", "usePfCandidateMultiMap not supported when useParticleFlow is set to true");
+ 
   // produces vector of muons
   produces<std::vector<Electron> >();
   }
@@ -550,12 +555,16 @@ void PATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
   }
 
   else{
-    // Try to access PF electron collection
-    edm::Handle<edm::ValueMap<reco::PFCandidatePtr> >ValMapH;
-    bool valMapPresent = iEvent.getByToken(pfCandidateMapToken_,ValMapH);
-    // Try to access a PFCandidate collection, as supplied by the user
-    edm::Handle< reco::PFCandidateCollection >  pfElectrons;
-    bool pfCandsPresent = iEvent.getByToken(pfElecToken_, pfElectrons);
+    edm::Handle<reco::PFCandidateCollection>  pfElectrons;
+    edm::Handle<edm::ValueMap<reco::PFCandidatePtr>> ValMapH;
+    edm::Handle<edm::ValueMap<std::vector<reco::PFCandidateRef>>> ValMultiMapH;
+    bool pfCandsPresent = false, valMapPresent = false;
+    if (usePfCandidateMultiMap_) {
+        iEvent.getByToken(pfCandidateMultiMapToken_, ValMultiMapH);
+    } else {
+        pfCandsPresent = iEvent.getByToken(pfElecToken_, pfElectrons);
+        valMapPresent = iEvent.getByToken(pfCandidateMapToken_,ValMapH);
+    }
 
     for (edm::View<reco::GsfElectron>::const_iterator itElectron = electrons->begin(); itElectron != electrons->end(); ++itElectron) {
       // construct the Electron from the ref -> save ref to original object
@@ -569,7 +578,15 @@ void PATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
       // Is this GsfElectron also identified as an e- in the particle flow?
       bool pfId = false;
 
-      if ( pfCandsPresent ) {
+      if (usePfCandidateMultiMap_) {
+        for (const reco::PFCandidateRef pf : (*ValMultiMapH)[elePtr]) {
+            if (pf->particleId() == reco::PFCandidate::e) {
+                pfId = true;
+                anElectron.setPFCandidateRef( pf );
+                break;
+            }
+        }
+      } else if ( pfCandsPresent ) {
 	// PF electron collection not available.
 	const reco::GsfTrackRef& trkRef = itElectron->gsfTrack();
 	int index = 0;
@@ -1007,6 +1024,11 @@ void PATElectronProducer::fillDescriptions(edm::ConfigurationDescriptions & desc
 
   // pf specific parameters
   iDesc.add<edm::InputTag>("pfElectronSource", edm::InputTag("pfElectrons"))->setComment("particle flow input collection");
+  auto && usePfCandidateMultiMap = edm::ParameterDescription<bool>("usePfCandidateMultiMap", false, true);
+  usePfCandidateMultiMap.setComment("take ParticleFlow candidates from pfCandidateMultiMap instead of matching to pfElectrons by Gsf track reference");
+  iDesc.ifValue(usePfCandidateMultiMap,
+    true  >> edm::ParameterDescription<edm::InputTag>("pfCandidateMultiMap", true) or
+    false >> edm::EmptyGroupDescription());
   iDesc.add<bool>("useParticleFlow", false)->setComment("whether to use particle flow or not");
   iDesc.add<bool>("embedPFCandidate", false)->setComment("embed external particle flow object");
 

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.h
@@ -92,8 +92,10 @@ namespace pat {
 
       /// pflow specific
       const bool          useParticleFlow_;
+      const bool          usePfCandidateMultiMap_;
       const edm::EDGetTokenT<reco::PFCandidateCollection> pfElecToken_;
       const edm::EDGetTokenT<edm::ValueMap<reco::PFCandidatePtr> > pfCandidateMapToken_;
+      const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > pfCandidateMultiMapToken_;
       const bool          embedPFCandidate_;
 
       /// mva input variables

--- a/PhysicsTools/PatAlgos/python/producersLayer1/electronProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/electronProducer_cfi.py
@@ -8,6 +8,7 @@ patElectrons = cms.EDProducer("PATElectronProducer",
     useParticleFlow  =  cms.bool( False ),
     pfElectronSource = cms.InputTag("particleFlow"),
     pfCandidateMap = cms.InputTag("particleFlow:electrons"),
+    usePfCandidateMultiMap = cms.bool( False ),
 
     # collections for mva input variables
     reducedBarrelRecHitCollection = cms.InputTag("reducedEcalRecHitsEB"),

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -39,6 +39,8 @@ def miniAOD_customizeCommon(process):
     process.patElectrons.embedPflowPreshowerClusters    = False  ## process.patElectrons.embed in AOD externally stored the electron's pflow preshower clusters
     process.patElectrons.embedRecHits         = False  ## process.patElectrons.embed in AOD externally stored the RecHits - can be called from the PATElectronProducer
     process.patElectrons.electronSource = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
+    process.patElectrons.usePfCandidateMultiMap = True
+    process.patElectrons.pfCandidateMultiMap    = cms.InputTag("reducedEgamma","reducedGsfElectronPfCandMap")
     process.patElectrons.electronIDSources = cms.PSet(
             # configure many IDs as InputTag <someName> = <someTag> you
             # can comment out those you don't want to save some disk space


### PR DESCRIPTION
Fix from @gpertuc
miniAOD: PATElectronProducer: link to PFCandidates using the existing association map instead of the gsf track ref